### PR TITLE
Validate and generate (but mostly validate) JSDoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /bower_components
 /node_modules
+/docs

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,13 +49,23 @@ module.exports = function (grunt) {
             options: {
                 config: ".jscsrc"
             }
+        },
+        jsdoc: {
+            dist: {
+                src: ["src"],
+                options: {
+                    destination: "docs",
+                    recurse: true
+                }
+            }
         }
     });
 
     grunt.loadNpmTasks("grunt-contrib-jshint");
     grunt.loadNpmTasks("grunt-jscs");
+    grunt.loadNpmTasks("grunt-jsdoc");
 
-    grunt.registerTask("test", ["jshint", "jscs"]);
+    grunt.registerTask("test", ["jshint", "jscs", "jsdoc"]);
 
     grunt.registerTask("default", ["test"]);
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-jscs": "^1.6.0",
+    "grunt-jsdoc": "^0.6.7",
     "jscs-trailing-whitespace-in-source": "0.0.1"
   }
 }

--- a/src/lib/artboard.js
+++ b/src/lib/artboard.js
@@ -33,7 +33,7 @@ define(function (require, exports) {
      * Creates a new artboard at the given location
      *
      * @param {ActionDescriptor} layerRef Reference object to layers that will be added to artboard
-     * @param {bottom: <number>, top: <number>, left: <number>, right: <number>} boundingBox
+     * @param {{bottom: number, top: number, left: number, right: number}} boundingBox
      * @return {PlayObject}
      */
     var makeArtboard = function (layerRef, boundingBox) {
@@ -61,7 +61,7 @@ define(function (require, exports) {
      * Moves/resized the referenced artboard layer to a new bounding box
      *
      * @param {ActionDescriptor} ref - Artboard layer reference
-     * @param {bottom: <number>, top: <number>, left: <number>, right: <number>} boundingBox
+     * @param {{bottom: number, top: number, left: number, right: number}} boundingBox
      * @return {PlayObject}
      */
     var transformArtboard = function (ref, boundingBox) {

--- a/src/lib/hitTest.js
+++ b/src/lib/hitTest.js
@@ -56,9 +56,9 @@ define(function (require, exports) {
      *
      * @param {object} documentRef Target document
      * @param {number} px X coordinate - horizontal
-     * @param {[type]} py Y coordinate - vertical
+     * @param {number} py Y coordinate - vertical
      *
-     * @return {{sampleData: <boolean>, colorSampler: <object>}} [description]
+     * @return {{sampleData: boolean, colorSampler: object}} [description]
      */
     var colorSampleAtPoint = function (documentRef, px, py) {
         return new PlayObject(

--- a/src/os.js
+++ b/src/os.js
@@ -204,7 +204,10 @@ define(function (require, exports, module) {
         return _os.resetCursorAsync(options);
     };
 
-    /** @type {OS} The OS singleton */
+    /**
+     * The OS singleton
+     * @type {OS}
+     */
     var theOS = new OS();
 
     // bind native phtooshop event handler to our handler function

--- a/src/ps.js
+++ b/src/ps.js
@@ -29,8 +29,8 @@ define(function (require, exports) {
     var Promise = require("bluebird");
 
     /**
-     * @private
      * Promisified version of _spaces.ps functions.
+     * @private
      */
     var _ps = Promise.promisifyAll(_spaces.ps);
 

--- a/src/ps/descriptor.js
+++ b/src/ps/descriptor.js
@@ -57,14 +57,16 @@ define(function (require, exports, module) {
     util.inherits(Descriptor, EventEmitter);
 
     /**
+     * Low-level promisified get function.
      * @private
-     * @type {function():Promise} Low-level promisified get function.
+     * @type {function():Promise}
      */
     Descriptor.prototype._getAsync = null;
 
     /**
+     * Low-level promisified batchPlay function.
      * @private
-     * @type {function():Promise} Low-level promisified batchPlay function.
+     * @type {function():Promise}
      */
     Descriptor.prototype._batchPlayAsync = null;
 
@@ -90,7 +92,7 @@ define(function (require, exports, module) {
      * Emit the named event with the given arguments as parameters. Throws if the
      * event is "error" and there are no listeners.
      * 
-     * @override EventEmitter.prototype.emitEvent
+     * @see EventEmitter.prototype.emitEvent
      * @param {string|RegExp} event Name of the event to emit and execute listeners for
      * @param {Array=} args Optional array of arguments to be passed to each listener
      * @return {object} Current instance for chaining
@@ -314,7 +316,7 @@ define(function (require, exports, module) {
      * while executing action descriptors: DONT_DISPLAY, DISPLAY and SILENT.
      * 
      * @const
-     * @type {Object.<string: number>}
+     * @type {Object.<string, number>}
      */
     Descriptor.prototype.interactionMode = _spaces.ps.descriptor.interactionMode;
 
@@ -631,7 +633,8 @@ define(function (require, exports, module) {
     };
 
     /**
-     * @type {Descriptor} The Descriptor singleton
+     * The Descriptor singleton
+     * @type {Descriptor} 
      */
     var descriptor = new Descriptor();
 

--- a/src/ps/ui.js
+++ b/src/ps/ui.js
@@ -138,7 +138,7 @@ define(function (require, exports, module) {
      * Overscroll modes
      * 
      * @const
-     * @type{object.<number>}
+     * @type{Object.<string, number>}
      */
     UI.prototype.overscrollMode = _spaces.ps.ui.overscrollMode;
 
@@ -395,7 +395,8 @@ define(function (require, exports, module) {
     };
 
     /**
-     * @type {UI} The UI singleton
+     * The UI singleton
+     * @type {UI}
      */
     var ui = new UI();
 


### PR DESCRIPTION
Just like adobe-photoshop/spaces-design#1643, this adds a `jsdoc` Grunt subtask, and adds it to the default `test` task.