### PR TITLE
OS.getTempFilename API

### DIFF
--- a/src/os.js
+++ b/src/os.js
@@ -207,7 +207,7 @@ define(function (require, exports, module) {
     /**
      * Gets a temporary file location, with a given name if provided
      *
-     * @param {string?} name File name for the temporary file
+     * @param {string=} name File name for the temporary file
      *
      * @return {Promise.<string>} Resolves to the temporary path
      */

--- a/src/os.js
+++ b/src/os.js
@@ -205,6 +205,21 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Gets a temporary file location, with a given name if provided
+     *
+     * @param {string?} name File name for the temporary file
+     *
+     * @return {Promise.<string>} Resolves to the temporary path
+     */
+    OS.prototype.getTempFilename = function (name) {
+        var options = {
+            name: name || ""
+        };
+
+        return _os.getTempFilenameAsync(options);
+    };
+
+    /**
      * The OS singleton
      * @type {OS}
      */


### PR DESCRIPTION
Will be used for libraries API, today's Jenkins build has the fix so it works correctly.