### PR TITLE
Updates from playground-dev/ (Perforce)

### DIFF
--- a/docs/SpacesExtension.js
+++ b/docs/SpacesExtension.js
@@ -1268,6 +1268,11 @@ _spaces.os.notifierKind = {
     "convertibleSlateMode":  a boolean, true => tablet mode, false => laptop mode
     */
     CONVERTIBLE_SLATE_MODE_CHANGED: "convertibleSlateModeChanged",
+    
+    
+    /** This notifier is sent when display configuration changes
+    */
+    DISPLAY_CONFIGURATION_CHANGED: "displayConfigurationChanged",
 };
 
 // TODO: Delete after 8/20/2014


### PR DESCRIPTION
SpacesExtension.js: (@1037966)
- DISPLAY_CONFIGURATION_CHANGED added to _spaces.os.notifierKind

low-level-test.js (@1038504)
- Added helper function getOpenDocumentCount() to enable validating special case issues
  where whether a document is open or not affects API behavior
- Added validation logic to "_spaces.os.keyboardFocus: acquire() / release() / isActive() functional"
  test to account for an edge case bug (uses new getOpenDocumentCount() helper function)
- Added identity coverage for _spaces.os.notifierKind.DISPLAY_CONFIGURATION_CHANGED
- Improvements to _spaces.os.getTempFilename() test