### PR TITLE
Get text color as a single object, not first of an array

### DIFF
--- a/src/lib/textLayer.js
+++ b/src/lib/textLayer.js
@@ -598,9 +598,9 @@ define(function (require, exports) {
             styleDescriptor.size = unitsIn[style.fontSize.type](style.fontSize.value);
         }
 
-        if (style.color && style.color[0] && style.color[0].value) {
-            assert(style.color[0].mode === "RGB", "text style being applied is not in RGB colorspace");
-            styleDescriptor.color = colorObject(style.color[0].value);
+        if (style.color && style.color.value) {
+            assert(style.color.mode === "RGB", "text style being applied is not in RGB colorspace");
+            styleDescriptor.color = colorObject(style.color.value);
         }
 
         // This can be zero!


### PR DESCRIPTION
WIll help address adobe-photoshop/spaces-design#2255, we store the color in it's own object now.