### PR TITLE
vector mask selection changes

### DIFF
--- a/src/lib/tool.js
+++ b/src/lib/tool.js
@@ -104,7 +104,11 @@ define(function (require, exports) {
         );
     };
 
-
+    /**
+     * Tool Mode possible values
+     *
+     * @type {Object.<string, number>}
+     */
     var toolModes = {
         SHAPE: 0,
         PATH: 1

--- a/src/lib/tool.js
+++ b/src/lib/tool.js
@@ -105,19 +105,26 @@ define(function (require, exports) {
     };
 
 
+    var toolModes = {
+        SHAPE: 0,
+        PATH: 1
+    };
+
     /**
-     * Resets the mode of shape tools back to "shape" from "path" or "pixel".
+     * sets the mode of shape tools  0=vtmShapeLayer, 1=vtmPath, 2=vtmFill
+     *
+     * @param {number} toolMode The type that we are applying to the tool 
      * 
      * @return {PlayObject}
      */
-    var resetShapeTool = function () {
+    var setShapeToolMode = function (toolMode) {
         return new PlayObject(
-            "reset",
+            "set",
             {
-                null: {
+                "null": {
                     _ref: [
                         {
-                            _ref: null,
+                            _ref: "property",
                             _property: "vectorToolMode"
                         },
                         {
@@ -126,7 +133,8 @@ define(function (require, exports) {
                             _value: "targetEnum"
                         }
                     ]
-                }
+                },
+                "to": toolMode
             }
         );
     };
@@ -256,10 +264,11 @@ define(function (require, exports) {
         );
     };
 
+    exports.toolModes = toolModes;
     exports.setTool = setTool;
     exports.setToolOptions = setToolOptions;
     exports.setDirectSelectOptionForAllLayers = setDirectSelectOptionForAllLayers;
-    exports.resetShapeTool = resetShapeTool;
+    exports.setShapeToolMode = setShapeToolMode;
     exports.defaultShapeTool = defaultShapeTool;
     exports.resetTypeTool = resetTypeTool;
 });

--- a/src/lib/vectorMask.js
+++ b/src/lib/vectorMask.js
@@ -102,7 +102,7 @@ define(function (require, exports) {
      * 
      * @return {PlayObject}
      */
-    var editVectorMask = function () {
+    var selectVectorMask = function () {
         var vectMaskRef = {
             "_ref": "path",
             "_enum": "path",
@@ -137,9 +137,62 @@ define(function (require, exports) {
         });
     };
     
+    /**
+     * free transform the whole path of the targeted vector mask
+     * 
+     * @return {PlayObject}
+     */
+    var enterFreeTransformPathMode = function () {
+        var layerRef = {
+            "_ref": "layer",
+            "_enum": "ordinal",
+            "_value": "targetEnum"
+        },
+        propertyRef = {
+            _ref: "property",
+            _property: "freeTransformWholePath"
+        };
+        
+        return new PlayObject("set", {
+            "null": {
+                "_ref": [propertyRef, layerRef]
+            },
+            "_property": "freeTransformWholePath",
+            "suppressPlayLevelIncrease": true
+        });
+    };
+    /**
+     * create a reveal all vector mask on current layer
+     * 
+     * @return {PlayObject}
+     */
+    var createRevealAllMask = function () {
+        var desc = {
+            "null": {
+                "_ref": [{
+                    "_ref": "path"
+                }]
+            },
+            "at": {
+                "_ref": [{
+                    "_ref": "path",
+                    "_enum": "path",
+                    "_value": "vectorMask"
+                }]
+            },
+            "using": {
+                "_enum": "vectorMaskEnabled",
+                "_value": "revealAll"
+            }
+        };
+        return new PlayObject("make", desc);
+    };
+
+    exports.createRevealAllMask = createRevealAllMask;
+    exports.enterFreeTransformPathMode = enterFreeTransformPathMode;
     exports.activateVectorMaskEditing = activateVectorMaskEditing;
     exports.makeBoundsWorkPath = makeBoundsWorkPath;
-    exports.editVectorMask = editVectorMask;
+    exports.selectVectorMask = selectVectorMask;
     exports.deleteWorkPath = deleteWorkPath;
     exports.makeVectorMaskFromWorkPath = makeVectorMaskFromWorkPath;
 });

--- a/src/lib/vectorMask.js
+++ b/src/lib/vectorMask.js
@@ -144,14 +144,14 @@ define(function (require, exports) {
      */
     var enterFreeTransformPathMode = function () {
         var layerRef = {
-            "_ref": "layer",
-            "_enum": "ordinal",
-            "_value": "targetEnum"
-        },
-        propertyRef = {
-            _ref: "property",
-            _property: "freeTransformWholePath"
-        };
+                "_ref": "layer",
+                "_enum": "ordinal",
+                "_value": "targetEnum"
+            },
+            propertyRef = {
+                _ref: "property",
+                _property: "freeTransformWholePath"
+            };
         
         return new PlayObject("set", {
             "null": {


### PR DESCRIPTION
add enterFreeTransformPathMode command, and allow users to set the mode of vector tools to either path or shape. used by https://github.com/adobe-photoshop/spaces-design/pull/1970 