### PR TITLE
Change translate API to move from transform, because it's faster in PS

### DIFF
--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -628,16 +628,13 @@ define(function (require, exports) {
             y = _y || 0;
 
         return new PlayObject(
-            "transform",
+            "move",
             {
                 "null": ref,
-                "snapToDocBounds": true,
-                "position": {
-                    "_obj": "position",
-                    "_value": {
-                        "horizontal": inUnits.pixels(x),
-                        "vertical": inUnits.pixels(y)
-                    }
+                "to": {
+                    "_obj": "point",
+                    "horizontal": x,
+                    "vertical": y
                 }
             }
         );


### PR DESCRIPTION
Worked on this with Jesper... in PS world, calling "move" for just translating the layers is much much faster than calling "transform", so this is part 1 of a fix for https://github.com/adobe-photoshop/spaces-design/issues/2231.

Part 2 will be getting rid of the "break layers down to all the children" of _getMoveLayerActions... as for translate we don't really need to do it.