### PR TITLE
Add guideTarget only for artboard guides

### DIFF
--- a/src/lib/document.js
+++ b/src/lib/document.js
@@ -525,22 +525,26 @@ define(function (require, exports) {
                 ]
             };
               
-        var descriptor = {
-            null: reference,
-            new: {
-                "_obj": "guide",
-                "null": guideReference,
-                "orientation": {
-                    "_enum": "orientation",
-                    "_value": orientation
-                },
-                "position": unitsIn.pixels(position)
-            },
-            "guideTarget": {
+        var guideTarget = {
                 "_enum": "guideTarget",
-                "_value": isArtboardGuide ? "guideTargetSelectedArtboard" : "guideTargetDocument"
-            }
-        };
+                "_value": "guideTargetSelectedArtboard"
+            },
+            descriptor = {
+                null: reference,
+                new: {
+                    "_obj": "guide",
+                    "null": guideReference,
+                    "orientation": {
+                        "_enum": "orientation",
+                        "_value": orientation
+                    },
+                    "position": unitsIn.pixels(position)
+                }
+            };
+
+        if (isArtboardGuide) {
+            descriptor.guideTarget = guideTarget;
+        }
 
         return new PlayObject("newGuide", descriptor);
     };


### PR DESCRIPTION
Since PS changed, this will add guideTarget enum only when we're adding artboard guides. Will help solve https://github.com/adobe-photoshop/spaces-design/issues/2461