### PR TITLE
Add forceMRU argument to document.open, true unless provided otherwise

### DIFF
--- a/src/lib/document.js
+++ b/src/lib/document.js
@@ -54,8 +54,8 @@ define(function (require, exports) {
      * @param {object} settings.externalPreview.path File path of the preview.
      * @param {object} settings.externalPreview.width Pixel width of the preview.
      * @param {object} settings.externalPreview.height Pixel height of the preview.
-     *
-     * TODO doc
+     * @param {boolean=} settings.forceMRU Will save the image to Most Recently Used list only when true
+     *                                     default is true
      *
      * @return {PlayObject}
      *
@@ -77,7 +77,8 @@ define(function (require, exports) {
                 externalPreview: settings.externalPreview
             },
             fileType,
-            strIndex = sourceRef._path.lastIndexOf(".");
+            strIndex = sourceRef._path.lastIndexOf("."),
+            forceMRU = settings.forceMRU !== undefined ? settings.forceMRU : true;
 
         if (strIndex !== -1) {
             strIndex++;
@@ -128,6 +129,8 @@ define(function (require, exports) {
                 };
             }
         }
+
+        desc.forceMRU = forceMRU;
 
         return new PlayObject(
             "open",


### PR DESCRIPTION
Jesper introduced a new setting to document.open descriptor, which allows us to force file to be added to most recently used. Right now, PS adds opened files to MRU list for ALL files played through external UI, because play level doesn't match. 

I'm providing it "true" to be default because we want most of our opens to be added to MRU unless the file is a library file.

This is one of those PRs with 3 parts, one here, one in spaces-design, and one in perforce.