### PR TITLE
Specify pixel units in layer transform action descriptor

### DIFF
--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -624,8 +624,8 @@ define(function (require, exports) {
      */
     var translate = function (ref, _x, _y) {
         assert(referenceOf(ref) === "layer", "translate is passed a non-layer reference");
-        var x = _x || 0,
-            y = _y || 0;
+        var x = inUnits.pixels(_x || 0),
+            y = inUnits.pixels(_y || 0);
 
         return new PlayObject(
             "move",


### PR DESCRIPTION
I _think_ PS is interpreting our x/y coordinates in points by default, which is the same as pixels for 72dpi documents. For different resolutions, the translation is not 1:1, so the results are skewed. This forces PS to interpret the coordinate arguments as pixels.

Addresses adobe-photoshop/spaces-design#3121. 

This definitely needs testing. It seemed to solve the problem for artboard swapping, but I haven't yet attempted to test it on other high-level actions which boil down to a "transform" command.