### PR TITLE
Organize adapter code to be bundleable, and fully connected with each other.

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,0 +1,28 @@
+define(function (require, exports) {
+    "use strict";
+
+    exports.application = require("./application");
+    exports.artboard = require("./artboard");
+    exports.bounds = require("./bounds");
+    exports.brushes = require("./brushes");
+    exports.color = require("./color");
+    exports.contentLayer = require("./contentLayer");
+    exports.document = require("./document");
+    exports.generator = require("./generator");
+    exports.history = require("./history");
+    exports.hitTest = require("./hitTest");
+    exports.layer = require("./layer");
+    exports.layerEffect = require("./layerEffect");
+    exports.libraries = require("./libraries");
+    exports.path = require("./path");
+    exports.photoshopEvent = require("./photoshopEvent");
+    exports.preference = require("./preference");
+    exports.reference = require("./reference");
+    exports.ruler = require("./ruler");
+    exports.selection = require("./selection");
+    exports.shape = require("./shape");
+    exports.textLayer = require("./textLayer");
+    exports.tool = require("./tool");
+    exports.unit = require("./unit");
+    exports.vectorMask = require("./vectorMask");
+});

--- a/src/main.js
+++ b/src/main.js
@@ -146,4 +146,10 @@ define(function (require, exports) {
     exports.openURLInDefaultBrowser = openURLInDefaultBrowser;
     exports.getPropertyValue = getPropertyValue;
     exports.setPropertyValue = setPropertyValue;
+    
+    exports.lib = require("./lib/index");
+    exports.os = require("./os");
+    exports.ps = require("./ps");
+    exports.util = require("./util");
+    exports.PlayObject = require("./playObject");
 });

--- a/src/ps.js
+++ b/src/ps.js
@@ -90,4 +90,7 @@ define(function (require, exports) {
     exports.endModalToolState = endModalToolState;
     exports.performMenuCommand = performMenuCommand;
     exports.logHeadlightsEvent = logHeadlightsEvent;
+
+    exports.ui = require("./ps/ui");
+    exports.descriptor = require("./ps/descriptor");
 });


### PR DESCRIPTION
This is a step we need to take for moving to webpack / other module loaders. And it's tied to a big PR that will happen on spaces-design side that is a change we can make independent of all the webpack efforts. 

We've been requiring spaces-adapter directly as a source, and requiring files from it a way project requires it's own files. While this has worked so far... it's not a good practice and prevents us from bundling spaces-adapter seperately. 

This change by itself is safe and will not work current spaces-design.