### PR TITLE
Linter cleanup

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -18,6 +18,9 @@
     ],
     "disallowMixedSpacesAndTabs": true,
     "disallowMultipleSpaces": true,
+    "disallowNestedTernaries": {
+        "maxLevel": 1
+    },
     "disallowNewlineBeforeBlockStatements": true,
     "disallowOperatorBeforeLineBreak": [
         "."
@@ -43,6 +46,7 @@
     "disallowSpacesInsideArrayBrackets": "nested",
     "disallowSpacesInsideBrackets": true,
     "disallowSpacesInsideParentheses": true,
+    "disallowTabs": true,
     "disallowTrailingComma": true,
     "disallowTrailingWhitespaceInSource": true,
     "esnext": true,
@@ -51,6 +55,7 @@
         ".jshintrc",
         "*.json"
     ],
+    "fileExtensions": [".js"],
     "maximumLineLength": 120,
     "requireBlocksOnNewline": 1,
     "requireCamelCaseOrUpperCaseIdentifiers": true,
@@ -85,14 +90,12 @@
         "<="
     ],
     "requirePaddingNewLinesAfterUseStrict": true,
-    "requirePaddingNewlinesBeforeKeywords": [
-        "do",
-        "for",
-        "while"
-    ],
     "requireParenthesesAroundIIFE": true,
     "requireSemicolons": true,
     "requireSpaceAfterBinaryOperators": true,
+    "requireSpaceAfterComma": {
+        "allExcept": ["trailing"]
+    },
     "requireSpaceAfterKeywords": true,
     "requireSpaceAfterLineComment": true,
     "requireSpaceBeforeBinaryOperators": true,
@@ -134,10 +137,41 @@
         "self"
     ],
     "validateIndentation": 4,
-    "validateJSDoc": {
+    "jsDoc": {
+        "checkAnnotations": {
+            "preset": "closurecompiler",
+            "extra": {
+                "callback": true
+            }
+        },
         "checkParamNames": true,
         "requireParamTypes": true,
-        "checkRedundantParams": true
+        "checkRedundantParams": true,
+        "checkReturnTypes": true,
+        "checkRedundantReturns": true,
+        "requireReturnTypes": true,
+        "enforceExistence": {
+            "allExcept": ["exports"]
+        },
+        "enforceExistenceExcept": [
+            "get",
+            "setup",
+            "value",
+            "beforeStartup",
+            "initialize",
+            "render",
+            "getState",
+            "getInitialState",
+            "getDefaultProps",
+            "getStateFromFlux",
+            "componentWillReceiveProps",
+            "componentWillMount",
+            "componentWillUnmount",
+            "componentDidMount",
+            "shouldComponentUpdate",
+            "componentWillUpdate",
+            "componentDidUpdate"
+        ]
     },
     "validateLineBreaks": "LF",
     "validateParameterSeparator": ", ",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,14 +58,40 @@ module.exports = function (grunt) {
                     recurse: true
                 }
             }
+        },
+        jsonlint: {
+            src: [
+                "*.json",
+                "src/**/*.json",
+                "test/**/*.json"
+            ]
+        },
+        lintspaces: {
+            src: [
+                "*",
+                "src/**/*.json",
+                "src/**/*.js"
+            ],
+            options: {
+                newline: true,
+                newlineMaximum: 1
+            }
+        },
+        concurrent: {
+            test: ["jshint", "jscs", "jsdoc", "jsonlint", "lintspaces"]
         }
     });
 
     grunt.loadNpmTasks("grunt-contrib-jshint");
     grunt.loadNpmTasks("grunt-jscs");
     grunt.loadNpmTasks("grunt-jsdoc");
+    grunt.loadNpmTasks("grunt-jsonlint");
+    grunt.loadNpmTasks("grunt-lintspaces");
 
-    grunt.registerTask("test", ["jshint", "jscs", "jsdoc"]);
+    grunt.loadNpmTasks("grunt-concurrent");
+
+    grunt.registerTask("seqtest", ["jshint", "jscs", "jsdoc", "jsonlint", "lintspaces"]);
+    grunt.registerTask("test", ["concurrent:test"]);
 
     grunt.registerTask("default", ["test"]);
 };

--- a/package.json
+++ b/package.json
@@ -15,9 +15,14 @@
   "homepage": "https://github.com/adobe-photoshop/spaces-adapater",
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-contrib-jshint": "^0.11.2",
-    "grunt-jscs": "^1.6.0",
-    "grunt-jsdoc": "^0.6.7",
-    "jscs-trailing-whitespace-in-source": "0.0.1"
+    "grunt-concurrent": "^2.0.4",
+    "grunt-contrib-jshint": "^0.11.3",
+    "grunt-jscs": "^2.3.0",
+    "grunt-jsdoc": "^1.0.0",
+    "grunt-jsonlint": "^1.0.6",
+    "grunt-lintspaces": "^0.7.1",
+    "jscs-jsdoc": "shaoshing/jscs-jsdoc#7fbf64b",
+    "jscs-trailing-whitespace-in-source": "0.0.1",
+    "node-lintspaces": "shaoshing/node-lintspaces"
   }
 }

--- a/src/lib/application.js
+++ b/src/lib/application.js
@@ -21,7 +21,6 @@
  * 
  */
 
-
 define(function (require, exports) {
     "use strict";
 
@@ -58,6 +57,5 @@ define(function (require, exports) {
     };
 
     exports.getFontList = getFontList;
-
     exports.referenceBy = referenceBy;
 });

--- a/src/lib/contentLayer.js
+++ b/src/lib/contentLayer.js
@@ -226,8 +226,6 @@ define(function (require, exports) {
         );
     };
 
-
-
     /**
      * @param {ActionDescriptor} sourceRef Reference to layer(s) to edit
      * @param {string} cap The stroke path cap. "square", "round", or "butt"
@@ -268,7 +266,7 @@ define(function (require, exports) {
      */
     var setStrokeCorner = function (sourceRef, corner) {
         assert(referenceOf(sourceRef) === "contentLayer", "setStrokeCorner is passed a non-layer reference");
-        return new PlayObject (
+        return new PlayObject(
             "set",
             {
                 "null": sourceRef,
@@ -321,7 +319,6 @@ define(function (require, exports) {
         };
         return new PlayObject("set", descriptor);
     };
-
 
     /**
      * Set shape fill to solid color with RGB color
@@ -689,7 +686,7 @@ define(function (require, exports) {
      * @param {string} typeShape The type of shape to create. "rectangle" for
      *      Rectangle or Rounded Rectangle, "ellipse" for Ellipse
      * @param {array} shapeVal The array of pixelsUnit values.
-                      rectangle for [top,bottom,left,right,topleft,topright,bottomleft,bottomright],
+     *                rectangle for [top,bottom,left,right,topleft,topright,bottomleft,bottomright],
      *                ellipse for [top,bottom,left,right]
      * y,x
      *

--- a/src/lib/document.js
+++ b/src/lib/document.js
@@ -21,18 +21,17 @@
  * 
  */
 
-
 define(function (require, exports) {
     "use strict";
+
+    var _ = require("lodash");
 
     var PlayObject = require("../playObject"),
         referenceBy = require("./reference").wrapper("document"),
         referenceOf = require("./reference").refersTo,
         unitsIn = require("./unit"),
-        assert = require("../util").assert,
-        _ = require("lodash");
+        assert = require("../util").assert;
         
-
     /**
      * Open a document (psd, png, jpg, ai, gif)
      * 
@@ -202,7 +201,7 @@ define(function (require, exports) {
      * @param {number} settings.jpgProgressiveScans The number of Scans. 3 to 5
      * @param {number} settings.pngCompression PNG compression. none or smallest
      * @param {number} settings.pngInterlace PNG interlace. none or interlaced
-
+     *
      * @param {boolean} settings.embedProfiles Whether embed color profile
      * 
      * @return {PlayObject}
@@ -371,13 +370,14 @@ define(function (require, exports) {
 
     /**
      * Create a document
-     * 
+     *
+     * @param {object} settings
      * @param {number} settings.width The document width.
      * @param {number} settings.height The document height.
      * @param {number} settings.resolution The document resolution.
      * @param {string} settings.fill The document fill. "white", "backgroundColor", "transparency"
      * @param {string} settings.colorMode The document color mode. "RGBColorMode", "bitmapMode", "grayscaleMode" 
-                        "CMYKColorMode", "labColorMode"
+     *  "CMYKColorMode", "labColorMode"
      * @param {number} settings.depth The color mode depth
      * @param {string} settings.colorProfile The document color profile. "sRGB IEC61966-2.1", "Adobe RGB (1998)",
      *  default: "none"

--- a/src/lib/hitTest.js
+++ b/src/lib/hitTest.js
@@ -21,7 +21,6 @@
  * 
  */
 
-
 define(function (require, exports) {
     "use strict";
 

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -109,7 +109,6 @@ define(function (require, exports) {
         }
     });
 
-
     /**
      * Moves the source layer to right before target reference 
      * (usually done by id)
@@ -503,8 +502,6 @@ define(function (require, exports) {
             }
         );
     };
-
-
 
     /**
      * FIXME: Only works with current document!

--- a/src/lib/layerEffect.js
+++ b/src/lib/layerEffect.js
@@ -248,6 +248,13 @@ define(function (require, exports) {
         return layerEffectPsProperties;
     };
 
+    /**
+     * FIXME: Needs explanation.
+     *
+     * @private
+     * @param {object} properties
+     * @return {boolean}
+     */
     var _isHiddenLayerProperties = function (properties) {
         return properties.enabled === false && properties.present === false;
     };
@@ -318,11 +325,11 @@ define(function (require, exports) {
         return _layerEffectDescriptor(ref, effectType, descriptorValue, true);
     };
 
-
     /**
      * Representation of a hidden layer effect.
      *
-     * @constant {object}
+     * @const
+     * @type {object}
      */
     var HIDDEN_LAYER_EFFECT_PROPERTIES = { "enabled": false, "present": false };
 

--- a/src/lib/photoshopEvent.js
+++ b/src/lib/photoshopEvent.js
@@ -21,7 +21,6 @@
  * 
  */
 
-
 define(function (require, exports) {
     "use strict";
 
@@ -29,9 +28,7 @@ define(function (require, exports) {
      * Returns the target of the event by parsing the action descriptor
      * 
      * @param {ActionDescriptor} event
-     *
-     * @return {string} Target of the event
-     *
+     * @return {?string} Target of the event
      */
     var targetOf = function (event) {
         if (event.hasOwnProperty("new")) {

--- a/src/lib/reference.js
+++ b/src/lib/reference.js
@@ -49,6 +49,12 @@ define(function (require, exports, module) {
         }
     };
 
+    /**
+     * FIXME: Needs explanation.
+     *
+     * @param {string} className
+     * @return {object}
+     */
     var wrapper = function (className) {
         /**
          * This function is boiler plate for creating reference objects
@@ -92,7 +98,6 @@ define(function (require, exports, module) {
              * @returns {ActionDescriptor} Reference to the given IDs
              */
             id: referenceBy.bind(null, "_id"),
-            
             
             /**
              * @param {int} Offset amount

--- a/src/lib/ruler.js
+++ b/src/lib/ruler.js
@@ -30,7 +30,7 @@ define(function (require, exports) {
      * Set Photoshop to use the ruler unit preference of our choice
      *
      * @param {string} type -  ruler unit type ie "rulerPixels"
-     * @returns {PlayObject} 
+     * @return {PlayObject} 
      */
     var setRulerUnits = function (type) {
         return new PlayObject("set", {
@@ -57,6 +57,12 @@ define(function (require, exports) {
         });
     };
 
+    /**
+     * FIXME: Needs explanation.
+     *
+     * @param {boolean} visible
+     * @return {PlayObject}
+     */
     var setRulerVisibility = function (visible) {
         return new PlayObject("set", {
             "null": {

--- a/src/lib/textLayer.js
+++ b/src/lib/textLayer.js
@@ -21,7 +21,6 @@
  * 
  */
 
-
 define(function (require, exports) {
     "use strict";
 
@@ -609,7 +608,6 @@ define(function (require, exports) {
         } else if (style.letterSpacing) {
             styleDescriptor.tracking = style.letterSpacing.value;
         }
-
 
         if (style.adbeAutoLeading) {
             styleDescriptor.autoLeading = style.adbeAutoLeading;

--- a/src/lib/tool.js
+++ b/src/lib/tool.js
@@ -27,7 +27,6 @@ define(function (require, exports) {
     var PlayObject = require("../playObject"),
         color = require("./color");
 
-
     /**
      * Sets the current tool to given tool
      *
@@ -142,7 +141,6 @@ define(function (require, exports) {
             }
         );
     };
-
 
     /**
      * Sets the default values of the shape tool

--- a/src/lib/unit.js
+++ b/src/lib/unit.js
@@ -21,8 +21,6 @@
  * 
  */
  
- // This is a wrapper to create unit descriptors
-
 define(function (require, exports) {
     "use strict";
 
@@ -35,24 +33,6 @@ define(function (require, exports) {
             _value: val
         };
     };
-
-    // TODO: Later on we need a better translation method here
-    // var _toInches = {
-    //     rulerInches: 1,
-    //     pointsUnit: 1 / 72,
-    //     millimetersUnit: 1 / 25.4,
-    //     rulerCm: 1 / 2.54
-    // };
-    // 
-    // var toPixels = function (unitValue, resolution) {
-    //     var rawValue = unitValue._value;
-    //     var unit = unitValue._unit;
-    // 
-    //     var factor = unit === "pixelsUnit" ? 1 : resolution * _toInches[unit];
-    // 
-    //     return rawValue * factor;
-    // };
-
 
     exports.density = _unit.bind(null, "density");
     exports.pixels = exports.px = _unit.bind(null, "pixels");
@@ -73,6 +53,4 @@ define(function (require, exports) {
     
     // Guides use this
     exports.distance = _unit.bind(null, "distance");
-
-    // exports.toPixels = toPixels;
 });

--- a/src/lib/vectorMask.js
+++ b/src/lib/vectorMask.js
@@ -108,7 +108,6 @@ define(function (require, exports) {
         });
     };
 
-
     /**
      * Delete the current vector mask on the current layer
      * 
@@ -148,7 +147,6 @@ define(function (require, exports) {
         });
     };
     
-
     /**
      * drops the selection on the current path
      * 

--- a/src/main.js
+++ b/src/main.js
@@ -115,10 +115,23 @@ define(function (require, exports) {
         }
     });
 
+    /**
+     * Asynchronously get the value of a Photoshop property.
+     *
+     * @param {string} name
+     * @return {Promise}
+     */
     var getPropertyValue = function (name) {
         return _main.getPropertyValueAsync(name, {});
     };
 
+    /**
+     * Asynchronously set the value of a Photoshop property.
+     *
+     * @param {string} name
+     * @param {string} value
+     * @return {Promise}
+     */
     var setPropertyValue = function (name, value) {
         return _main.setPropertyValueAsync(name, value, {});
     };

--- a/src/os.js
+++ b/src/os.js
@@ -62,7 +62,7 @@ define(function (require, exports, module) {
      * OS notifier kinds
      * 
      * @const
-     * @type{Object.<string, number>}
+     * @type {Object.<string, number>}
      */
     OS.prototype.notifierKind = _os.notifierKind;
 
@@ -70,7 +70,7 @@ define(function (require, exports, module) {
      * OS event kinds
      * 
      * @const
-     * @type{Object.<string, number>}
+     * @type {Object.<string, number>}
      */
     OS.prototype.eventKind = _os.eventKind;
 
@@ -78,7 +78,7 @@ define(function (require, exports, module) {
      * OS event modifiers
      * 
      * @const
-     * @type{Object.<string, number>}
+     * @type {Object.<string, number>}
      */
     OS.prototype.eventModifiers = _os.eventModifiers;
 
@@ -86,10 +86,9 @@ define(function (require, exports, module) {
      * OS event keyCodes
      * 
      * @const
-     * @type{Object.<string, number>}
+     * @type {Object.<string, number>}
      */
     OS.prototype.eventKeyCode = _os.eventKeyCode;
-
 
     /**
      * Event handler for events from the native bridge.

--- a/src/playObject.js
+++ b/src/playObject.js
@@ -65,6 +65,5 @@ define(function (require, exports, module) {
      */
     PlayObject.prototype.options = null;
 
-    
     module.exports = PlayObject;
 });

--- a/src/ps.js
+++ b/src/ps.js
@@ -33,7 +33,6 @@ define(function (require, exports) {
      * @private
      */
     var _ps = Promise.promisifyAll(_spaces.ps);
-
     
     /**
      * Commit or cancel the current modal tool edit state.

--- a/src/ps/descriptor.js
+++ b/src/ps/descriptor.js
@@ -133,6 +133,8 @@ define(function (require, exports, module) {
         }
 
         Descriptor.super_.prototype.emitEvent.call(this, event, args);
+
+        return this;
     };
 
     /** 

--- a/src/ps/ui.js
+++ b/src/ps/ui.js
@@ -138,7 +138,7 @@ define(function (require, exports, module) {
      * Overscroll modes
      * 
      * @const
-     * @type{Object.<string, number>}
+     * @type {Object.<string, number>}
      */
     UI.prototype.overscrollMode = _spaces.ps.ui.overscrollMode;
 

--- a/src/util.js
+++ b/src/util.js
@@ -48,6 +48,12 @@ define(function (require, exports) {
         });
     };
 
+    /**
+     * Throw an exception with the given message if the provided value is not truthy.
+     *
+     * @param {boolean} expression
+     * @param {string} message
+     */
     var assert = function (expression, message) {
         console.assert(expression, message);
     };

--- a/test/specs.js
+++ b/test/specs.js
@@ -36,6 +36,13 @@ define(function (require, exports) {
         ]
     };
 
+
+    /**
+     * FIXME: Needs explanation.
+     *
+     * @param {string} specClass
+     * @return {Array.<string>}
+     */
     var getSpecsByClass = function (specClass) {
         var section = specClass || "unit",
             tests = [];

--- a/test/testrunner.js
+++ b/test/testrunner.js
@@ -47,6 +47,12 @@ define(function (require) {
         };
     };
 
+    /**
+     * FIXME: Needs explanation.
+     *
+     * @private
+     * @return {object}
+     */
     var _parseQueryString = function () {
         var queryString = window.location.search.substr(1), // trims off initial "?"
             parts = queryString.split("&"),
@@ -62,6 +68,11 @@ define(function (require) {
         return result;
     };
 
+    /**
+     * FIXME: Needs explanation.
+     *
+     * @private
+     */
     var _loadTestsAndStart = function () {
         var parsedQueryString = _parseQueryString(),
             section = parsedQueryString.section,


### PR DESCRIPTION
This cleans up the linters to generally mirror those in spaces-design:

1. Upgrade `jscs` and copy its `.jscsrc` config over from spaces-design.
2. Add `jsonlint`.
3. Add `lintspaces`.
4. Run linters concurrently with `grunt-concurrent`.