### PR TITLE
Upgrade lodash to 3.10

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "spaces-adapter",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "homepage": "https://github.com/adobe-photoshop/spaces-api",
   "authors": [
     "Joel Brandt <jobrandt@adobe.com>",

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "eventEmitter": "~4.2.11",
     "bluebird": "~2.9.24",
-    "lodash": "~3.8.0"
+    "lodash": "~3.10.1"
   },
   "devDependencies": {
     "requirejs": "~2.1.17",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "bugs": {
     "url": "https://github.com/adobe-photoshop/spaces-adapater/issues"
   },
+  "main": "src/main.js",
   "homepage": "https://github.com/adobe-photoshop/spaces-adapater",
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaces-adapter",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "JavaScript adapter for the Adobe Photoshop Spaces plugin",
   "scripts": {
     "test": "grunt test"

--- a/src/ps/descriptor.js
+++ b/src/ps/descriptor.js
@@ -151,7 +151,7 @@ define(function (require, exports, module) {
      */
     var _wrap = function (reference, multiGetProperties) {
         if (Array.isArray(reference)) {
-            reference = _.chain(reference)
+            reference = _.chain(_.cloneDeep(reference))
                 .map(function (ref) {
                     return _wrap(ref);
                 })

--- a/src/ps/ui.js
+++ b/src/ps/ui.js
@@ -213,7 +213,7 @@ define(function (require, exports, module) {
      */
     UI.prototype.setClassicChromeVisibility = function (visible) {
         return this.setSuppressScrollbars(!visible).then(function () {
-            _ui.setWidgetTypeVisibilityAsync(ALL_NONWINDOW_WIDGETS_BITMASK, visible);
+            return _ui.setWidgetTypeVisibilityAsync(ALL_NONWINDOW_WIDGETS_BITMASK, visible);
         });
     };
 


### PR DESCRIPTION
We've been using lodash 3.8, but all new libraries use 3.10 and it's good to stay up to date.

However, _.chain().reverse() function mutates the array in place, which causes problems when we call `addLayers`. So this change upgrades lodash and also fixes that issue.

I've also upgraded spaces-adapter version to 0.27.0 so it's not randomly picked up by people.

Other change is making sure a promise returns in the handler so bluebird doesn't complain in it's newer version.