### PR TITLE
Remove ai specific parameterization of documentLib.open

### DIFF
--- a/src/lib/document.js
+++ b/src/lib/document.js
@@ -98,37 +98,6 @@ define(function (require, exports) {
             };
         }
 
-        if (fileType === "ai") {
-            desc.as = {};
-            desc.as._obj = "PDFGenericFormat";
-            desc.as._value.selection = {
-                "_enum": "pdfSelection",
-                "_value": params.pdfSelection
-            };
-            desc.as._value.suppressWarnings = params.suppressWarnings;
-            desc.as._value.pageNumber = params.pageNumber;
-            
-            if (params.pdfSelection === "page") {
-                desc.as._value = {
-                    "antiAlias": params.bAntiAlias,
-                    "constrainProportions": params.bConstrainProportions,
-                    "crop": {
-                        "_enum": "cropTo",
-                        "_value": openDocument.cropTo[params.box]
-                    },
-                    "depth": params.bitDepth,
-                    "width": unitsIn.pixels(params.width),
-                    "height": unitsIn.pixels(params.height),
-                    "mode": {
-                        "_enum": "colorSpace",
-                        "_value": openDocument.mode[params.colorSpace]
-                    },
-                    "name": params.name,
-                    "resolution": unitsIn.density(params.resolution)
-                };
-            }
-        }
-
         desc.forceMRU = forceMRU;
 
         return new PlayObject(


### PR DESCRIPTION
This is one of the oldest lib functions we have (one of the first actually), and it doesn't work correctly since we don't provide any parameters for things like drop, width, depth, height when we try to open the files.

So I'm removing it. If, in the future we start saving open parameters of files, it'll be available there. And if PS sees it fit, it will show the Import PDF dialog anyways.

Addresses https://github.com/adobe-photoshop/spaces-design/issues/3253