### PR TITLE
Add Promise.config to disable warnings

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -146,6 +146,14 @@ define(function (require, exports) {
         return _main.openURLInDefaultBrowserAsync(url);
     };
 
+    // TODO: Currently it is VERY hard to pinpoint the origin of Bluebird
+    // warnings. When that improves, we should enable this and then fix the
+    // sources of the warnings.
+    Promise.config({
+        warnings: false,
+        cancellation: true
+    });
+
     exports.isPluginCompatible = isPluginCompatible;
     exports.openURLInDefaultBrowser = openURLInDefaultBrowser;
     exports.getPropertyValue = getPropertyValue;


### PR DESCRIPTION
Will address https://github.com/adobe-photoshop/spaces-design/issues/3398, and when adapter is npm-linked, not show Promise warnings.