### PR TITLE
Add getMouseLocation API to OS

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,7 +37,7 @@ define(function (require, exports) {
     var COMPATIBLE_PLUGIN_VERSION = {
         major: 2,
         minor: 0,
-        patch: 14
+        patch: 15
     };
 
     /**

--- a/src/os.js
+++ b/src/os.js
@@ -219,6 +219,16 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Returns the current mouse location synchronously
+     * Synchronous as it is ran in V8 and does not communicate with Photoshop
+     *
+     * @return {Array.<number>} X and Y locations of the mouse
+     */
+    OS.prototype.getMouseLocation = function () {
+        return _spaces.os.getMouseLocation();
+    };
+
+    /**
      * The OS singleton
      * @type {OS}
      */


### PR DESCRIPTION
This is a new synchronous API that's just added. It directly interfaces with V8 to get the current mouse location relative to the app frame top left. 
Requires playground-dev-mac #972 or later.