### PR TITLE
Update compatible plugin version spec for 3.1.x series

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -35,7 +35,7 @@ define(function (require, exports) {
      * @const
      * @type {string}
      */
-    const COMPATIBLE_PLUGIN_VERSIONS = "~2.1.0||~3.0.0";
+    const COMPATIBLE_PLUGIN_VERSIONS = "^3.0.0";
 
     /**
      * Check if the current plugin version is compatible with the specified


### PR DESCRIPTION
This changes `COMPATIBLE_PLUGIN_VERSIONS` to be `~3.0.0`, disallowing `2.x` plugins but allowing `3.1.x` plugins.

Over to @mcilroyc for a santiy check.