### PR TITLE
getApplicationFrameInfo

### DIFF
--- a/src/lib/document.js
+++ b/src/lib/document.js
@@ -35,7 +35,7 @@ export const referenceOf = refersTo;
  * Open a document (psd, png, jpg, ai, gif)
  * 
  * @param {ActionDescriptor} sourceRef document reference
- * @param {object} settings
+ * @param {object=} settings
  * @param {string} settings.pdfSelection "page" or "image"
  * @param {number} settings.pageNumber The number of the page
  * @param {boolean} settings.suppressWarnings true or false
@@ -58,7 +58,7 @@ export const referenceOf = refersTo;
  * @return {PlayObject}
  *
  */
-export function openDocument (sourceRef, settings) {
+export function openDocument (sourceRef, settings = {}) {
     var params = {
             pdfSelection: settings.pdfSelection || "page",
             pageNumber: settings.pageNumber || 1,

--- a/src/lib/owl.js
+++ b/src/lib/owl.js
@@ -137,6 +137,18 @@ export function getDocumentPresets () {
 }
 
 /**
+ * Get the global bounds of the application frame.
+ *
+ * @return {PlayObject}
+ */
+export function getApplicationFrameInfo () {
+    return new PlayObject("owlAction", {
+        "null": referenceBy.current,
+        "owlCommand": "getApplicationFrameInfo"
+    });
+}
+
+/**
  * Gets the information on all the tools from Photoshop
  *
  * @return {PlayObject}

--- a/src/ps/descriptor.js
+++ b/src/ps/descriptor.js
@@ -153,6 +153,16 @@ class Descriptor extends EventEmitter {
          * @type {Object.<string, number>}
          */
         this.interactionMode = _spaces.ps.descriptor.interactionMode;
+
+        /**
+         * Promisified version of sendDirectMessage
+         *
+         * @private
+         * @type {function():Promise}
+         */
+        this._sendDirectMessageAsync = Promise.promisify(_spaces.ps.descriptor.sendDirectMessage, {
+            context: _spaces.ps.descriptor
+        });
     }
 
     /**
@@ -183,6 +193,18 @@ class Descriptor extends EventEmitter {
      */
     off (event, listener) {
         return this.removeListener(event, listener);
+    }
+
+    /**
+     * Send a direct message to Photoshop.
+     *
+     * @param {string} name
+     * @param {object} payload
+     * @param {object=} options
+     * @return {Promise}
+     */
+    sendDirectMessage (name, payload, options = {}) {
+        return this._sendDirectMessageAsync(name, payload, options);
     }
 
     /**


### PR DESCRIPTION
1. Add the `getApplicationFrameInfo` OWL action, which allows us to get the bounds of the Photoshop window.
2. Add a default value (`{}`) for the settings argument on `document.openDocument`.
3. Expose a promisified version of `sendDirectMessage` on `Descriptor` instances.