### PR TITLE
Expose performIdentify

### DIFF
--- a/src/ps/ui.js
+++ b/src/ps/ui.js
@@ -396,6 +396,16 @@ class UI extends EventEmitter {
     startEditWithCurrentModalTool () {
         return _ui.startEditWithCurrentModalToolAsync();
     }
+
+    /**
+     * Visually identify a rectangular area in the UI.
+     *
+     * @param {{left: number, top: number, right: number, bottom: number}} globalBounds
+     * @return {Promise}
+     */
+    performIdentify (globalBounds) {
+        return _ui.performIdentifyAsync({ globalBounds }, {});
+    }
 }
 
 /**


### PR DESCRIPTION
Expose the `performIdentify` command to visually identify rectangular areas in the UI.