### PR TITLE
Add getViewList

### DIFF
--- a/src/lib/owl.js
+++ b/src/lib/owl.js
@@ -213,6 +213,20 @@ export function getMenuCommands () {
 }
 
 /**
+ * Get a list of all available views.
+ *
+ * @param {string} panel
+ * @return {PlayObject}
+ */
+export function getViewList (panel) {
+    return new PlayObject("uiInfo", {
+        "null": referenceBy.current,
+        "command": "getViewList",
+        "panel": panel
+    });
+}
+
+/**
  * Returns information on a view with the given viewID in the given panel
  * including it's bounds, whether it's shown or not and it's control state
  *


### PR DESCRIPTION
Adds a `getViewList` method to construct `PlayObject`s that return a list of the available views.