### PR TITLE
Require client to instantiate adapter classes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,24 +1,24 @@
 /*
  * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
- *  
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"), 
- * to deal in the Software without restriction, including without limitation 
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- *  
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *  
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
- * 
+ *
  */
 
 /* global _spaces */
@@ -60,7 +60,7 @@ export const compatiblePluginVersion = COMPATIBLE_PLUGIN_VERSIONS;
  * Abort the current application and return control to Classic Photoshop.
  * If a message is supplied, Classic Photoshop may display it to the user,
  * e.g., in a dialog.
- * 
+ *
  * @param {{message: string=}}
  * @return {Promise}
  */
@@ -69,7 +69,7 @@ export const abort = _main.abortAsync;
 /**
  * Check if the current plugin version is compatible with the specified
  * minimum-compatible plugin version.
- * 
+ *
  * @return {boolean}
  */
 export function isPluginCompatible () {
@@ -126,7 +126,7 @@ import * as ps from "./ps";
 import * as util from "./util";
 import * as window from "./window";
 import * as ims from "./ims";
-import os from "./os";
+import * as os from "./os";
 import PlayObject from "./playObject";
 import lib from "./lib";
 

--- a/src/os.js
+++ b/src/os.js
@@ -48,42 +48,42 @@ var _clipboard = Promise.promisifyAll(_spaces.os.clipboard);
  * @constructor
  * @private
  */
-class OS extends EventEmitter {
+export class OS extends EventEmitter {
     constructor () {
         super();
-
-        /**
-         * OS notifier kinds
-         *
-         * @const
-         * @type {Object.<string, number>}
-         */
-        this.notifierKind = _os.notifierKind;
-
-        /**
-         * OS event kinds
-         *
-         * @const
-         * @type {Object.<string, number>}
-         */
-        this.eventKind = _os.eventKind;
-
-        /**
-         * OS event modifiers
-         *
-         * @const
-         * @type {Object.<string, number>}
-         */
-        this.eventModifiers = _os.eventModifiers;
-
-        /**
-         * OS event keyCodes
-         *
-         * @const
-         * @type {Object.<string, number>}
-         */
-        this.eventKeyCode = _os.eventKeyCode;
     }
+
+    /**
+     * OS notifier kinds
+     *
+     * @const
+     * @type {Object.<string, number>}
+     */
+    static get notifierKind () { return _os.notifierKind; }
+
+    /**
+     * OS event kinds
+     *
+     * @const
+     * @type {Object.<string, number>}
+     */
+    static get eventKind () { return _os.eventKind; }
+
+    /**
+     * OS event modifiers
+     *
+     * @const
+     * @type {Object.<string, number>}
+     */
+    static get eventModifiers () { return _os.eventModifiers; }
+
+    /**
+     * OS event keyCodes
+     *
+     * @const
+     * @type {Object.<string, number>}
+     */
+    static get eventKeyCode () { return _os.eventKeyCode; }
 
     /**
      * Event handler for events from the native bridge.
@@ -278,12 +278,16 @@ class OS extends EventEmitter {
 }
 
 /**
- * The OS singleton
- * @type {OS}
+ * Construct an OS object with the given options.
+ *
+ * @param {object=} options
+ * @return {OS}
  */
-const theOS = new OS();
+export function makeOS (options = {}) {
+    let os = new OS();
 
-// bind native Photoshop event handler to our handler function
-_spaces.setNotifier(_spaces.notifierGroup.OS, {}, theOS._eventHandler.bind(theOS));
+    // bind native Photoshop event handler to our handler function
+    _spaces.setNotifier(_spaces.notifierGroup.OS, options, os._eventHandler.bind(os));
 
-export default theOS;
+    return os;
+}

--- a/src/playObject.js
+++ b/src/playObject.js
@@ -21,10 +21,21 @@
  * 
  */
 
-import Descriptor from "./ps/descriptor";
+import { Descriptor } from "./ps/descriptor";
+
+/**
+ * Dummy instance that only hosts the play method.
+ *
+ * FIXME: Ideally Descriptor methods like playObject would be available
+ * statically, but that isn't a simple change because those methods aren't
+ * actually stateless due to the transaction infrastructure.
+ *
+ * @private
+ * @type {Descriptor}
+ */
+const _descriptor = new Descriptor();
 
 export default class PlayObject {
-
     /**
      * In Spaces-adapter, all library functions return PlayObjects. 
      * These PlayObjects can be called in Photoshop by passing them into 
@@ -52,9 +63,10 @@ export default class PlayObject {
     /**
      * Play this PlayObject.
      *
+     * @param {object=} options
      * @return {Promise}
      */
-    play () {
-        return Descriptor.playObject(this);
+    play (options) {
+        return _descriptor.playObject(this, options);
     }
 }

--- a/src/ps.js
+++ b/src/ps.js
@@ -1,24 +1,24 @@
 /*
  * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
- *  
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"), 
- * to deal in the Software without restriction, including without limitation 
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- *  
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *  
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
- * 
+ *
  */
 
 /* global _spaces */
@@ -43,7 +43,7 @@ export function endModalToolState (commit, options) {
     options = options || {
         invalidateMenus: true
     };
-    
+
     return _ps.endModalToolStateAsync(commit)
         .then(function () {
             return _ps.processQueuedCommandsAsync(options);
@@ -63,7 +63,7 @@ export function performMenuCommand (commandID) {
 
 /**
  * Log an analytics event using the Adobe Headlights API.
- * 
+ *
  * NOTE: This is an Adobe-private API that must not be used by third-party
  * developers!
  *
@@ -103,7 +103,7 @@ export function logHeadlightsDataGroup (info, options = {}) {
     return _ps.logHeadlightsDataGroupAsync(info, options);
 }
 
-import ui from "./ps/ui";
-import descriptor from "./ps/descriptor";
+import * as ui from "./ps/ui";
+import * as descriptor from "./ps/descriptor";
 
 export { ui, descriptor };

--- a/src/ps/ui.js
+++ b/src/ps/ui.js
@@ -62,50 +62,50 @@ var ALL_NONWINDOW_WIDGETS_BITMASK =
  * @constructor
  * @private
  */
-class UI extends EventEmitter {
+export class UI extends EventEmitter {
     constructor () {
         super();
-
-        /**
-         * Overscroll modes
-         * 
-         * @const
-         * @type {Object.<string, number>}
-         */
-        this.overscrollMode = _spaces.ps.ui.overscrollMode;
-
-        /**
-         * Pointer propagation modes - Used for the default mouse policy
-         * PROPAGATE_BY_ALPHA: Default behavior, events will be sent to Spaces
-         * if they're clicking on a Spaces view
-         * PROPAGATE_TO_PHOTOSHOP: Spaces will never get a pointer event
-         * PROPAGATE_TO_BROWSER: Spaces consumes all pointer events
-         */
-        this.pointerPropagationMode = _spaces.ps.ui.pointerPropagationMode;
-
-        /**
-         * Keyboard propagation modes - Used for the default keyboard policy
-         * PROPAGATE_BY_FOCUS: Default behavior, events will be sent to in focus element
-         * PROPAGATE_TO_PHOTOSHOP: Spaces will never get a keyboard event
-         * PROPAGATE_TO_BROWSER: Spaces consumes all keyboard events
-         */
-        this.keyboardPropagationMode = _spaces.ps.ui.keyboardPropagationMode;
-
-        /**
-         * Policy action modes - Used for custom policies
-         * Numerically, they're identical for keyboard and pointer
-         * PROPAGATE_BY_ALPHA (applies as PROPAGATE_BY_FOCUS on Keyboard events)
-         * PROPAGATE_TO_PHOTOSHOP
-         * PROPAGATE_TO_BROWSER
-         */
-        this.policyAction = _spaces.ps.ui.policyAction;
-
-        /**
-         * Command kinds - Used for certain commands that are also used in
-         * OS dialogs (like copy/paste), with USER_DEFINED as extra
-         */
-        this.commandKind = _spaces.ps.ui.commandKind;
     }
+
+    /**
+     * Overscroll modes
+     * 
+     * @const
+     * @type {Object.<string, number>}
+     */
+    static get overscrollMode () { return _spaces.ps.ui.overscrollMode; }
+
+    /**
+     * Pointer propagation modes - Used for the default mouse policy
+     * PROPAGATE_BY_ALPHA: Default behavior, events will be sent to Spaces
+     * if they're clicking on a Spaces view
+     * PROPAGATE_TO_PHOTOSHOP: Spaces will never get a pointer event
+     * PROPAGATE_TO_BROWSER: Spaces consumes all pointer events
+     */
+    static get pointerPropagationMode () { return _spaces.ps.ui.pointerPropagationMode; }
+
+    /**
+     * Keyboard propagation modes - Used for the default keyboard policy
+     * PROPAGATE_BY_FOCUS: Default behavior, events will be sent to in focus element
+     * PROPAGATE_TO_PHOTOSHOP: Spaces will never get a keyboard event
+     * PROPAGATE_TO_BROWSER: Spaces consumes all keyboard events
+     */
+    static get keyboardPropagationMode () { return _spaces.ps.ui.keyboardPropagationMode; }
+
+    /**
+     * Policy action modes - Used for custom policies
+     * Numerically, they're identical for keyboard and pointer
+     * PROPAGATE_BY_ALPHA (applies as PROPAGATE_BY_FOCUS on Keyboard events)
+     * PROPAGATE_TO_PHOTOSHOP
+     * PROPAGATE_TO_BROWSER
+     */
+    static get policyAction () { return _spaces.ps.ui.policyAction; }
+
+    /**
+     * Command kinds - Used for certain commands that are also used in
+     * OS dialogs (like copy/paste), with USER_DEFINED as extra
+     */
+    static get commandKind () { return _spaces.ps.ui.commandKind; }
 
     /**
      * Event handler for menu events from the native bridge.
@@ -409,25 +409,37 @@ class UI extends EventEmitter {
 }
 
 /**
- * The UI singleton
- * @type {UI}
+ * Construct a UI object with the given options.
+ *
+ * @param {object=} options
+ * @param {object=} options.menu
+ * @param {object=} options.interaction
+ * @param {number} options.interaction.notificationKind
+ * @return {UI}
  */
-const theUI = new UI();
+export function makeUI (options = {}) {
+    let menu = options.menu || {},
+        interaction = options.interaction || {},
+        ui = new UI();
 
-// Install the menu notifier group handler
-_spaces.setNotifier(_spaces.notifierGroup.MENU, {}, theUI._menuEventHandler.bind(theUI));
+    // Install the menu notifier group handler
+    _spaces.setNotifier(_spaces.notifierGroup.MENU, menu, ui._menuEventHandler.bind(ui));
 
-// Install the interaction notifier group handler. For now, listen to "options" and
-// "context" and "error" events, but not "progress" events, because listening for
-// a particular class of events also suppresses the corresponding interaction dialog.
-// In the case of "error" events, only an internally black-listed set of dialogs are
-// suppresesed.
-let _interactionOpts = _spaces.notifierOptions.interaction;
-_spaces.setNotifier(_spaces.notifierGroup.INTERACTION, {
-    notificationKind:
-        _interactionOpts.OPTIONS +
-        _interactionOpts.CONTEXT +
-        _interactionOpts.ERROR
-}, theUI._interactionEventHandler.bind(theUI));
+    // Install the interaction notifier group handler. For now, listen to "options" and
+    // "context" and "error" events, but not "progress" events, because listening for
+    // a particular class of events also suppresses the corresponding interaction dialog.
+    // In the case of "error" events, only an internally black-listed set of dialogs are
+    // suppresesed.
+    let _interactionOpts = _spaces.notifierOptions.interaction;
 
-export default theUI;
+    if (!interaction.notificationKind) {
+        interaction.notificationKind =
+            _interactionOpts.OPTIONS +
+            _interactionOpts.CONTEXT +
+            _interactionOpts.ERROR;
+    }
+
+    _spaces.setNotifier(_spaces.notifierGroup.INTERACTION, interaction, ui._interactionEventHandler.bind(ui));
+
+    return ui;
+}

--- a/src/util.js
+++ b/src/util.js
@@ -24,21 +24,6 @@
 /* global console */
 
 /**
- * Inherit the prototype methods from one constructor into another.
- *
- * Modeled after Node's util.inherits, which is licensed under the MIT license
- *   Implementation: https://github.com/joyent/node/blob/master/lib/util.js#L628
- *   License: https://github.com/joyent/node/blob/master/LICENSE
- *
- * @param {function} ctor Constructor function which needs to inherit the prototype.
- * @param {function} superCtor Constructor function to inherit prototype from.
- */
-export function inherits (ctor, superCtor) {
-    ctor.super_ = superCtor;
-    Object.setPrototypeOf(ctor.prototype, superCtor.prototype);
-}
-
-/**
  * Throw an exception with the given message if the provided value is not truthy.
  *
  * @param {boolean} expression


### PR DESCRIPTION
With this PR, clients must now instantiate event-emitting adapter classes `Descriptor`, `UI` and `OS` classes. Singletons are no longer exported. This change is motivated by a requirement that `Descriptor` not sign up for notifications of _all_ Photoshop events for performance reasons. Instead, only the subset of notifications required for the application should be forwarded, and this set should be specified by the client at the time of instantiation. To simplify this process, each class now has an associated construction function that sets up event notification and connects it to a returned instance.

This is a breaking API change. Besides requiring clients to create (and share internally) their own instances of these classes, various enums that were previously instance members are now static, which means they can no longer be accessed directly the instances. Once merged, the major version of this package should be incremented.

Other small clean-ups: `PlayObject.prototype.play()` now accepts an options parameter; and `util.inherits` has been removed, having been necessitated by ES2015 inheritance, implemented by babel.