### PR TITLE
Pause descriptor events

### DIFF
--- a/src/playObject.js
+++ b/src/playObject.js
@@ -24,7 +24,7 @@
 import { Descriptor } from "./ps/descriptor";
 
 /**
- * Dummy instance that only hosts the play method.
+ * Dummy instance that only hosts the play method and listens for no events.
  *
  * FIXME: Ideally Descriptor methods like playObject would be available
  * statically, but that isn't a simple change because those methods aren't
@@ -33,7 +33,7 @@ import { Descriptor } from "./ps/descriptor";
  * @private
  * @type {Descriptor}
  */
-const _descriptor = new Descriptor();
+const _descriptor = new Descriptor({ events: [] });
 
 export default class PlayObject {
     /**


### PR DESCRIPTION
This PR adds `pause` and `unpause` methods to `Descriptor`  in order to temporarily disable and reenable notifications from Photoshop. @jsbache tells me that this is required for us to be considered good Photoshop citizens, and we certainly consider ourselves as such!

`Descriptor` instances are paused by default, and set no Photoshop notifiers upon construction. Unpausing a `Descriptor` installs its Photoshop notifiers. `makeDescriptor` takes the liberty of calling`unpause` on the returned instance, so this only a breaking change _if you didn't use that API_. (Search does, but I'm not sure about Butler.) Pausing a descriptor uninstalls all of its notifiers, and hence causes it to stop emitting events.

If a client explicitly passes an empty list of events in the options argument, no notifiers are _ever_ set. This is important because utility instances of `Descriptor` (like, e.g., as used by `PlayObject`) must not interfere with the installed notifiers so as not to disrupt the primary client.

 A private `_paused` flag is used to ensure that both methods are idempotent. The `_psEventHandler` is now also bound just once in the constructor and re-used across unpausings.
