### PR TITLE
Update jsdoc for os.getStandardFolderPath

### DIFF
--- a/src/os.js
+++ b/src/os.js
@@ -270,7 +270,7 @@ class OS extends EventEmitter {
      *
      * @param {object} options
      * @param {string} options.kind "UserApplicationSupport" is the only supported kind currently.
-     * @return {Promise.<string>}
+     * @return {Promise.<{path: string}>}
      */
     getStandardFolderPath (options) {
         return _os.getStandardFolderPathAsync(options);


### PR DESCRIPTION
`os.getStandardFolderPath` will return an object instead of string after `pgdev 1760`. This PR updates the related JSDoc to reflect the change.