### PR TITLE
Remove unused dependencies from npm-shrinkwrap.json

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,21 +2,6 @@
   "name": "spaces-adapter",
   "version": "5.0.0",
   "dependencies": {
-    "bluebird": {
-      "version": "3.3.4",
-      "from": "bluebird@>=3.0.5 <4.0.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.4.tgz"
-    },
-    "lodash": {
-      "version": "3.10.1",
-      "from": "lodash@>=3.10.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-    },
-    "qunitjs": {
-      "version": "1.22.0",
-      "from": "qunitjs@>=1.20.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/qunitjs/-/qunitjs-1.22.0.tgz"
-    },
     "semver": {
       "version": "5.1.0",
       "from": "semver@>=5.1.0 <6.0.0",


### PR DESCRIPTION
These three dependencies are not listed in the `dependencies` list, which will cause the `extraneous: bluebird@3.3.4 .../spaces-adapter/node_modules/bluebird` error when running the `npm shrinkwrap` command in other projects. 

More details about the `extraneous` error https://github.com/thewoolleyman/npm-shrinkwrap-helper#npm-err-extraneous-