### PR TITLE
Remove promise config line from adapter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,14 +114,6 @@ export function openURLInDefaultBrowser (url) {
     return _main.openURLInDefaultBrowserAsync(url);
 }
 
-// TODO: Currently it is VERY hard to pinpoint the origin of Bluebird
-// warnings. When that improves, we should enable this and then fix the
-// sources of the warnings.
-Promise.config({
-    warnings: false,
-    cancellation: true
-});
-
 import * as ps from "./ps";
 import * as util from "./util";
 import * as window from "./window";


### PR DESCRIPTION
This removes the Promise config line to solve a problem with couple of our internal projects. It should be the client's responsibility and choice to configure bluebird anyways so this helps with the cleanup.

@iwehrman please review