### PR TITLE
Exclude peer dependency when bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ git clone git@github.com:adobe-photoshop/spaces-adapter.git
 cd spaces-adapter
 npm install
 npm link
- ./node_modules/.bin/webpack --debug --watch
+npm run dev
 
 # 2. Now you can make changes to spaces-adapter.
-# The `webpack` command will automatically pickup your changes
+# The `npm run dev` command will automatically pickup your changes
 # and rebuild the package in the `build` folder.
 
 # 3. Link the local spaces-adapter repo to your project.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "description": "JavaScript adapter for the Adobe Photoshop Spaces plugin",
   "scripts": {
     "test": "eslint src",
-    "prepublish": "webpack -p"
+    "prepublish": "webpack --production --config webpack-prd.config.js",
+    "dev": "webpack --debug --watch"
   },
   "repository": {
     "type": "git",

--- a/webpack-prd.config.js
+++ b/webpack-prd.config.js
@@ -1,0 +1,9 @@
+var base = require("./webpack.config.js");
+var webpack = require("webpack");
+
+module.exports = Object.assign({}, base, {
+    plugins: [
+        // Does not allow a bundle when there are errors present
+        new webpack.NoErrorsPlugin()
+    ]
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,10 @@ module.exports = {
         root: path.resolve("./src"),
         extensions: ["", ".js"]
     },
+    externals: {
+        // Exclude peerDependencies building
+        "bluebird": true
+    },
     module: {
         preLoaders: [
             {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,3 @@
-var webpack = require("webpack");
 var path = require("path");
 
 module.exports = {
@@ -39,9 +38,5 @@ module.exports = {
                 }
             }
         ]
-    },
-    plugins: [
-        // Does not allow a bundle when there are errors present
-        new webpack.NoErrorsPlugin()
-    ]
+    }
 };


### PR DESCRIPTION
The current release `5.1.0` accidentally bundles the `bluebird@2.11.0`, which could cause error for clients who uses the blurbird's `Cancellation` feature, which is not available in `2.x`. This PR marks `bluebird` as external dependency so that `webpack` command will not bundle the bluebird into the build. 

Other improvements: added `npm run dev` command for development. the command also ignores eslint errors, which will allow the use of `console.info` etc. However, publishing the package will still check for eslint errors.

