### PR TITLE
Allow notifierProxy to reset listened events

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "estraverse-fb": "^1.3.1",
     "grunt": "^0.4.5",
     "grunt-concurrent": "^2.0.4",
-    "grunt-eslint": "^17.3.1",
+    "grunt-eslint": "^19.0.0",
     "grunt-jscs": "^2.3.0",
     "grunt-jsdoc": "^1.0.0",
     "grunt-jsonlint": "^1.0.6",

--- a/src/util/notifierproxy.js
+++ b/src/util/notifierproxy.js
@@ -40,7 +40,7 @@ export default class NotifierProxy extends EventEmitter {
 
         let enabledEvents = null;
         if (!options.hasOwnProperty("events")) {
-            /* eslint no-console: 0 */
+            // eslint-disable-next-line no-console
             console.warn("Listening for all events is a potential performance problem.");
         } else if (options.events && options.events.length > 0) {
             // Used to verify at runtime that listeners are only added for enabled events.
@@ -227,7 +227,7 @@ export default class NotifierProxy extends EventEmitter {
         let enabledEvents = null;
 
         if (!events) {
-            /* eslint no-console: 0 */
+            // eslint-disable-next-line no-console
             console.warn("Listening for all events is a potential performance problem.");
         } else if (events && events.length > 0) {
             // Used to verify at runtime that listeners are only added for enabled events.


### PR DESCRIPTION
This is something we need with NotifierProxies, where events are not subscribed to once, but dynamically change through the life-time of the applications. 

Also fixed a bug with `addListener`, because in it's current state, it was not possible to listen to `"all"` events (workaround was to use `.on`, but that's hacky)

@shaoshing please review.