### PR TITLE
add APIs register/unregisterExternalEventNotification.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,8 @@
     "semi": [2, "always"],
     "indent": [2, 4],
     "jsx-quotes": 1,
-    "no-multiple-empty-lines": [2, {"max": 1}]
+    "no-multiple-empty-lines": [2, {"max": 1}],
+    "space-before-blocks": [ 2, "always" ],
+    "space-before-function-paren": [ 2, "always" ]
   }
 }


### PR DESCRIPTION
**requires pgdev mac >= 2134 win >= 2118**

This PR adds three APIs to accommodate with the new OS External Event Notification Mode added by John F. External events like `externalMouseDown` used to always send to the JS clients regardless of whether they are needed. With the added notification mode, PS will only send the external events that are registered by the clients. (currently these external events are on by default for transition purpose, and they will be turned off by the end of the week). The added APIs are listed below (please check their JSDoc for documentation):

* getExternalEventNotificationMode
* registerExternalEventNotification 
* unregisterExternalEventNotification

